### PR TITLE
Trello 2184

### DIFF
--- a/src/feature/Company/ProUserComponent.tsx
+++ b/src/feature/Company/ProUserComponent.tsx
@@ -140,12 +140,12 @@ export const ProUserComponent: React.FC<ProUserComponentProps> = ({id, connected
                 statusShortLabel={(s: ReportStatusPro) => m.reportStatusShortPro[s]}
                 statusColor={(s: ReportStatusPro) => reportStatusProColor[s]}
               />
-              <Panel>
+              {/* <Panel>
                 <PanelHead>{m.tags}</PanelHead>
                 <PanelBody>
                   <HorizontalBarChart data={tagsDistribution} grid />
                 </PanelBody>
-              </Panel>
+              </Panel> */}
               <Panel loading={_reports.result.isFetching}>
                 <PanelHead>{m.lastReports}</PanelHead>
                 {_reports.result.data && <ReportsShortList reports={_reports.result.data} />}
@@ -154,7 +154,7 @@ export const ProUserComponent: React.FC<ProUserComponentProps> = ({id, connected
             <Grid item sm={12} md={5}>
               <CompanyInfo company={company} />
               <ReviewDistribution companyId={id} />
-              <ReportWordDistribution companyId={id} />
+              {/* <ReportWordDistribution companyId={id} /> */}
             </Grid>
           </Grid>
         </>

--- a/src/feature/Report/ReportHeader.tsx
+++ b/src/feature/Report/ReportHeader.tsx
@@ -104,7 +104,7 @@ export const ReportHeader = ({report, children, elevated, isUserPro = false}: Pr
               )}
             </Box>
             {!hideSiret && <Box sx={{color: t => t.palette.text.disabled}}>{report.companyName}</Box>}
-            <Box sx={{color: t => t.palette.text.disabled}}>ID {report.id}</Box>
+            {/* <Box sx={{color: t => t.palette.text.disabled}}>ID {report.id}</Box> */}
             <ExpirationDate {...{report, isUserPro}} />
           </div>
           <ReportStatusLabel style={{marginLeft: 'auto'}} status={report.status} />
@@ -112,10 +112,10 @@ export const ReportHeader = ({report, children, elevated, isUserPro = false}: Pr
 
         <ExpiresSoonWarning {...{report, isUserPro}} />
 
-        <Alert id="report-info" dense type="info" deletable persistentDelete sx={{mb: 2}}>
+        {/* <Alert id="report-info" dense type="info" deletable persistentDelete sx={{mb: 2}}>
           {m.reportCategoriesAreSelectByConsumer}
-        </Alert>
-        <ReportCategories categories={[m.ReportCategoryDesc[report.category], ...report.subcategories]} />
+        </Alert> */}
+        {/* <ReportCategories categories={[m.ReportCategoryDesc[report.category], ...report.subcategories]} /> */}
       </PanelBody>
       {(!hideTags || children) && (
         <PanelFoot sx={css.actions} border>

--- a/src/feature/Report/ReportPro.tsx
+++ b/src/feature/Report/ReportPro.tsx
@@ -50,7 +50,7 @@ export const ReportPro = () => {
   }
 
   return (
-    <Page maxWidth="s" loading={_getReport.isLoading}>
+    <Page maxWidth="xl" loading={_getReport.isLoading}>
       {ScOption.from(_getReport.data?.report)
         .map(report => (
           <>

--- a/src/feature/ReportsPro/ReportsPro.tsx
+++ b/src/feature/ReportsPro/ReportsPro.tsx
@@ -36,6 +36,7 @@ import {Label} from '../../shared/Label'
 import {ScInput} from '../../shared/ScInput'
 import {useGetAccessibleByProQuery} from '../../core/queryhooks/companyQueryHooks'
 import {useReportSearchQuery} from '../../core/queryhooks/reportQueryHooks'
+import { useListReportBlockedNotificationsQuery } from 'core/queryhooks/reportBlockedNotificationQueryHooks'
 
 const css = makeSx({
   card: {
@@ -105,6 +106,7 @@ export const ReportsPro = () => {
 
   const _reports = useReportSearchQuery({offset: 0, limit: 10, ...queryString.get()})
   const _accessibleByPro = useGetAccessibleByProQuery()
+  const _blockedNotifications = useListReportBlockedNotificationsQuery()
 
   const {isMobileWidth} = useLayoutContext()
   const history = useHistory()
@@ -317,7 +319,15 @@ export const ReportsPro = () => {
                 </PanelBody>
               </Panel>
             )}
-
+        {
+          _blockedNotifications.data && _blockedNotifications.data.length > 0 && (
+          <Alert id="report-info" dense type="info" deletable sx={{mb: 2}}>
+                {_blockedNotifications.data.length === 1
+                  ? "Pensez à activer les notifications dans l'onglet « Mes entreprises » afin d'être alerté par e-mail de tout nouvel enregistrement de signalement."
+                  : `${_blockedNotifications.data.length} de vos entreprises n'ont pas les notifications actives. Activez-les dans 'Mes entreprises' pour être alerté immédiatement de tout nouveau signalement enregistré.`}
+            </Alert>
+          )
+        }
             <Panel>
               <Datatable<ReportSearchResult>
                 id="reportspro"

--- a/src/shared/ReportStatus.tsx
+++ b/src/shared/ReportStatus.tsx
@@ -24,9 +24,9 @@ export const reportStatusColor = {
 }
 
 export const reportStatusProColor = {
-  [ReportStatusPro.ARepondre]: '#e67e00',
-  [ReportStatusPro.NonConsulte]: '#8B0000',
-  [ReportStatusPro.Cloture]: '#3582A3FF',
+  [ReportStatusPro.ARepondre]: '#d64d00',
+  [ReportStatusPro.NonConsulte]: '#7b7b7b',
+  [ReportStatusPro.Cloture]: '#27a658',
 }
 
 const statusInvisibleToPro = [ReportStatus.NA, ReportStatus.LanceurAlerte]


### PR DESCRIPTION
Sur l’aperçu du signalement accessible depuis la vue principale suivi des signalements :

Modifier la largeur de la vue signalement

Retirer ID

Retirer les catégories + message bleu explicatif

Sur la vue principale suivi des signalements :

Code couleur statut des signalements à revoir

ajouter l’info : notifications mails désactivées  si cette option a été choisie dans les paramètres

Sur la vue « statistiques » accessible depuis l’onglet mes entreprises :

retirer tag

retirer le top 10 des mots les plus fréquents