### PR TITLE
Added feedback button

### DIFF
--- a/src/core/i18n/localization/en.ts
+++ b/src/core/i18n/localization/en.ts
@@ -63,5 +63,6 @@ export const en = {
       "Remember to activate notifications in the 'My Companies' tab to be alerted by email of any new report.",
     activateNotificationsAlertMultiple: (count: number) =>
       `${count} of your companies do not have notifications activated. Activate them in 'My Companies' to be immediately alerted of any new report.`,
+    Feedback: 'Feedback',
   },
 }

--- a/src/core/i18n/localization/fr.ts
+++ b/src/core/i18n/localization/fr.ts
@@ -123,6 +123,7 @@ export const fr = {
     activateNotificationsAlertMultiple: (count: number) => `
     ${count} de vos entreprises n'ont pas les notifications actives. Activez-les dans 'Mes entreprises' pour être alerté immédiatement de tout nouveau signalement.`,
     search: 'Rechercher',
+    Feedback: 'Donnez votre avis',
     edit: 'Modifier',
     next: 'Suivant',
     nextStep: 'Next step',

--- a/src/feature/ReportsPro/ReportsPro.tsx
+++ b/src/feature/ReportsPro/ReportsPro.tsx
@@ -140,16 +140,22 @@ export const ReportsPro = () => {
     <Page loading={_accessibleByPro.isLoading}>
       <PageTitle
         action={
-          <Btn
-            variant="outlined"
-            color="primary"
-            icon="help"
-            {...({target: '_blank'} as any)}
-            href={config.appBaseUrl + '/comment-ca-marche'}
-          >
-            {m.help}
-            <Icon sx={{ml: 1, color: t => t.palette.text.disabled}}>open_in_new</Icon>
-          </Btn>
+          <div className="flex gap-2">
+            <Btn variant="outlined" {...({target: '_blank'} as any)} href="https://tally.so/r/woMGGe">
+              {m.Feedback}
+              <Icon sx={{ml: 1}}>feedback</Icon>
+            </Btn>
+            <Btn
+              variant="outlined"
+              // color="primary"
+              // icon="help"
+              {...({target: '_blank'} as any)}
+              href={config.appBaseUrl + '/centre-aide'}
+            >
+              {m.help}
+              <Icon sx={{ml: 1}}>help</Icon>
+            </Btn>
+          </div>
         }
       >
         {m.reports_pageTitle}
@@ -474,10 +480,6 @@ export const ReportsPro = () => {
           </>
         ))
         .toUndefined()}
-      <Btn variant="outlined" {...({target: '_blank'} as any)} href="https://tally.so/r/woMGGe">
-        {m.Feedback}
-        <Icon sx={{ml: 1, color: t => t.palette.text.disabled}}>open_in_new</Icon>
-      </Btn>
     </Page>
   )
 }

--- a/src/feature/ReportsPro/ReportsPro.tsx
+++ b/src/feature/ReportsPro/ReportsPro.tsx
@@ -3,7 +3,7 @@ import {Page, PageTitle} from '../../shared/Page'
 import {Panel, PanelBody} from '../../shared/Panel'
 import {Datatable} from '../../shared/Datatable/Datatable'
 import {useI18n} from '../../core/i18n'
-import {Badge, Box, Grid, Icon, MenuItem} from '@mui/material'
+import {Badge, Box, Button, Grid, Icon, MenuItem} from '@mui/material'
 import {ReportStatusLabel, ReportStatusProLabel} from '../../shared/ReportStatus'
 import {useLayoutContext} from '../../core/Layout/LayoutContext'
 import {Alert, Btn, Fender, makeSx, Txt} from '../../alexlibs/mui-extension'
@@ -474,6 +474,10 @@ export const ReportsPro = () => {
           </>
         ))
         .toUndefined()}
+      <Btn variant="outlined" {...({target: '_blank'} as any)} href="https://tally.so/r/woMGGe">
+        {m.Feedback}
+        <Icon sx={{ml: 1, color: t => t.palette.text.disabled}}>open_in_new</Icon>
+      </Btn>
     </Page>
   )
 }


### PR DESCRIPTION
En tant que professionnel, je veux pouvoir faire un feedback facilement à l'équipe produit :

le bouton doit se trouver sur la vue principale “suivi des signalements”
le bouton doit être visible et l’intitulé clair “donnez votre avis”
l’action ouvre le formulaire Tally suivant : https://tally.so/r/woMGGe